### PR TITLE
Multiple LANGUAGE_ONLY tags

### DIFF
--- a/CHANGELOG-course.md
+++ b/CHANGELOG-course.md
@@ -1,5 +1,9 @@
 # Change log for `course`
 
+**Version 2.8.0**
+
+- course.cfg variables can override OS environment if `FORCE_[VARNAME]` flag is set.
+
 **Version 2.7.1**
 
 - Fixed a bug: `course build` failed to import the built DBC if build profiles

--- a/CHANGELOG-master_parse.md
+++ b/CHANGELOG-master_parse.md
@@ -1,5 +1,10 @@
 # Change Log for Master Parse Tool
 
+**Version 1.23.0**
+
+- If a cell has multiple LANGUAGE_ONLY (e.g. PYTHON_ONLY and SCALA_ONLY), it will include it if the notebook
+  language matches any of them.
+
 **Version 1.22.0**
 
 - Added `INSTRUCTOR_NOTES` alias for `INSTRUCTOR_NOTE`. Addresses

--- a/course/__init__.py
+++ b/course/__init__.py
@@ -24,7 +24,7 @@ from typing import (Generator, Sequence, Pattern, NoReturn, Optional, Any,
 # Constants
 # -----------------------------------------------------------------------------
 
-VERSION = '2.7.1'
+VERSION = '2.8.0'
 PROG = os.path.basename(sys.argv[0])
 
 CONFIG_PATH = os.path.expanduser("~/.databricks/course.cfg")
@@ -420,10 +420,10 @@ def load_config(config_path: str,
         # appropriate, and apply defaults.
         for e, default, _ in setting_keys_and_defaults:
             v = os.environ.get(e)
-            if v is not None:
+            if v is not None and ("FORCE_" + e) not in cfg:
                 cfg[e] = v
 
-            if (cfg.get(e) is None) and default:
+            if not cfg.get(e) and default:
                 t = StringTemplate(default)
                 cfg[e] = t.substitute(cfg)
 

--- a/master_parse/__init__.py
+++ b/master_parse/__init__.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass
 from typing import (Sequence, Optional, Dict, Set, NoReturn, Pattern, Match,
                     Tuple, List, TextIO, Any)
 
-VERSION = "1.22.0"
+VERSION = "1.23.0"
 
 # -----------------------------------------------------------------------------
 # Enums. (Implemented as classes, rather than using the Enum functional
@@ -430,7 +430,8 @@ class NotebookGenerator(object):
         self.discard_labels = base_keep - self.keep_labels
 
         # In kept cells, remove the following labels from the content
-        self.remove = [_dbc_only, _scala_only, _python_only, _new_part, _inline,
+        self.remove = [_scala_only, _python_only, _r_only, _sql_only,
+                       _dbc_only, _new_part, _inline,
                        _all_notebooks, _instructor_note, _instructor_notes,
                        _instructor_only, _video, _profiles, _azure_only,
                        _amazon_only, _ilt_only, _self_paced_only]
@@ -686,6 +687,14 @@ class NotebookGenerator(object):
                     discard_labels = self.discard_labels
 
                     all_notebooks = CommandLabel.ALL_NOTEBOOKS in labels
+
+                    # If a cell has more than one LANGUAGE_ONLY (e.g. SQL_ONLY and PYTHON_ONLY) and any of
+                    # them match the target language of the notebook, keep the cell.
+                    if (NotebookGenerator.param_to_label[self.notebook_code] & labels):
+                        for lang in CODE_CELL_TYPES:
+                            labels = labels - NotebookGenerator.param_to_label[lang]
+                        all_notebooks = True
+
                     if all_notebooks:
                         # There are some exceptions here. A cell marked
                         # ALL_NOTEBOOKS will still not be copied if it's


### PR DESCRIPTION
Multiple LANGUAGE_ONLY tags can be added to a cell.  If any match, the cell is included.

Seperately, the course tool is updated such that if FORCE_EDITOR is set in the config, then the config's editor will take precedence over the environment variable.